### PR TITLE
Support caching streaming files that have known checksums

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,19 +12,21 @@ var plugin = function(name, opt){
   }
 
   var stream = through.obj(function(file, enc, callback){
-    var contents = null;
+    var contents = file.checksum;
 
-    if (file.isStream()) {
-      this.push(file);
-      return callback();
-    }
-    if (file.isBuffer()) {
-      contents = file.contents.toString('utf8');
+    if (!contents) {
+      if (file.isStream()) {
+        this.push(file);
+        return callback();
+      }
+      if (file.isBuffer()) {
+        contents = file.contents.toString('utf8');
 
-      // slower for each file
-      // but good if you need to save on memory
-      if (opts.optimizeMemory) {
-        contents = crypto.createHash('md5').update(contents).digest('hex');
+        // slower for each file
+        // but good if you need to save on memory
+        if (opts.optimizeMemory) {
+          contents = crypto.createHash('md5').update(contents).digest('hex');
+        }
       }
     }
 

--- a/test/main.js
+++ b/test/main.js
@@ -151,4 +151,28 @@ describe('gulp-cached', function() {
     stream.write(file);
     stream.end();
   });
+
+  it('should create a cache that only allows a hashed streaming file through once', function(done) {
+    var file = new gutil.File({
+      path: "/home/file.js",
+      contents: new PassThrough()
+    });
+    file.checksum = 'deadbeef';
+    var stream = cache('testyeah');
+    var count = 0;
+    stream.on('data', function(nfile){
+      count++;
+      nfile.path.should.equal(file.path);
+    });
+    stream.on('end', function(){
+      count.should.equal(1);
+      done();
+    });
+    stream.write(file);
+    stream.write(file);
+    stream.write(file);
+    stream.write(file);
+    stream.write(file);
+    stream.end();
+  });
 });


### PR DESCRIPTION
When working with remote files, we often have some metadata that we can use for caching. It would be nice to use `gulp-cached` to conditionally process streams based on that metadata, the same way it works for local files.

I propose setting a `checksum` property on the Vinyl file in a task that loads metadata, and checking that property in `gulp-cached`.

For example: https://github.com/uts-magic-lab/gulp-google-drive